### PR TITLE
Rework PD terminate_process

### DIFF
--- a/epu/processdispatcher/test/mocks.py
+++ b/epu/processdispatcher/test/mocks.py
@@ -148,6 +148,13 @@ class MockNotifier(object):
         actual = self.processes[upid]['state']
         assert actual == state, "expected state %s, actual %s" % (state, actual)
 
+    def assert_no_process_state(self, upid=None):
+        if upid is None:
+            assert not self.processes, "expected no processes. got %s" % self.processes
+        else:
+            assert upid not in self.processes, \
+                "expected no process %s notification, got %s" % (upid, self.processes[upid])
+
 
 class FakeEEAgent(object):
     def __init__(self, dashi, heartbeat_dest, node_id, slot_count):


### PR DESCRIPTION
- better validation of parameters
- don't try to terminate any process in a terminal state, not just
  >= TERMINATED
- log process state changes
- fix race where TERMINATED heartbeats could be received before
  TERMINATING state was set -- this resulted in the PD assuming
  an erroneous termination, and restarting the process!
