### PR TITLE
Refresh node IP information even when the instance state stays the same

### DIFF
--- a/epu/epumanagement/core.py
+++ b/epu/epumanagement/core.py
@@ -292,7 +292,11 @@ class InstanceParser(object):
         d['error_time'] = previous.error_time if previous.error_time else None
         new = CoreInstance(**d)
 
-        if new.state <= previous.state:
+        previous_update_counter = previous.get('update_counter')
+        new_update_counter = new.get('update_counter')
+        if new.state < previous.state or (new.state == previous.state and
+                previous_update_counter and new_update_counter <=
+                previous_update_counter):
             log.warn("Instance %s: got out of order or duplicate state message!"+
             " It will be dropped: %s", instance_id, content)
             return None


### PR DESCRIPTION
This is a workaround for OpenStack, which returns the local hostname as
the public hostname for some time during the launch, even though the
instance is already running. At each IaaS query, we check if the
instance IP information has changed. If it does, we send a state update
to EPUM.

We make sure that EPUM does not process out of order messages by using
an update counter.
