### PR TITLE
Add fail_fast to provisioner threads.

### DIFF
--- a/epu/provisioner/leader.py
+++ b/epu/provisioner/leader.py
@@ -139,16 +139,16 @@ class ProvisionerLeader(object):
                         self.core.terminate_all()
 
             if self.terminator_thread is None:
-                self.terminator_thread = tevent.spawn(self.run_terminator)
+                self.terminator_thread = tevent.spawn(self.run_terminator, fail_fast=True)
 
             if self.site_query_thread is None:
-                self.site_query_thread = tevent.spawn(self.run_site_query_thread)
+                self.site_query_thread = tevent.spawn(self.run_site_query_thread, fail_fast=True)
 
             if self.context_query_thread is None:
-                self.context_query_thread = tevent.spawn(self.run_context_query_thread)
+                self.context_query_thread = tevent.spawn(self.run_context_query_thread, fail_fast=True)
 
             if self.record_reaper_thread is None:
-                self.record_reaper_thread = tevent.spawn(self.run_record_reaper_thread)
+                self.record_reaper_thread = tevent.spawn(self.run_record_reaper_thread, fail_fast=True)
 
             with self.condition:
                 if self.is_leader:

--- a/epu/provisioner/test/test_leader.py
+++ b/epu/provisioner/test/test_leader.py
@@ -86,4 +86,13 @@ class ProvisionerLeaderTests(unittest.TestCase):
             tevent.joinall([leader_thread])
         else:
             pid, exit = os.wait()
+
+            # exit is a 16-bit number, whose low byte is the signal number that
+            # killed the process, and whose high byte is the exit status (if
+            # the signal number is zero); the high bit of the low byte is set
+            # if a core file was produced.
+            #
+            # Check that the signal number is zero and the exit code is the
+            # expected one.
+            self.assertEqual(exit & 0xff, 0)
             self.assertEqual(exit >> 8 & 0xff, os.EX_SOFTWARE)

--- a/epu/provisioner/test/test_leader.py
+++ b/epu/provisioner/test/test_leader.py
@@ -5,6 +5,7 @@ import time
 import epu.tevent as tevent
 
 from mock import Mock, MagicMock
+from nose.plugins.skip import SkipTest
 
 from epu.provisioner.leader import ProvisionerLeader
 
@@ -57,3 +58,28 @@ class ProvisionerLeaderTests(unittest.TestCase):
         leader_thread.join(1)
         # TODO: PDA: test that thread exited cleanly?
         #self.assertTrue(leader_thread.successful())
+
+    def test_terminator_death(self):
+
+        # This test will bring down the nose process. To test it, comment
+        # out the following line, and ensure that the test brings down the
+        # nose test
+        raise SkipTest("Test should only be run manually, kills process")
+
+        core = Mock()
+        store = Mock()
+
+        def dies():
+            raise TypeError("thread dies!")
+
+        core._get_nodes_by_id = MagicMock(return_value=[])
+
+        leader = ProvisionerLeader(store, core)
+
+        leader.run_terminator = dies
+
+        leader.initialize()
+        store.contend_leader.assert_called_with(leader)
+
+        leader_thread = tevent.spawn(leader.inaugurate)
+

--- a/epu/test/test_tevent.py
+++ b/epu/test/test_tevent.py
@@ -1,6 +1,8 @@
-
 import time
+import socket
 import threading
+
+from mock import Mock
 
 import epu.tevent as tevent
 
@@ -22,3 +24,12 @@ def test_spawn():
     
     time.sleep(0.5)
     assert global_var == True
+
+def test_fail_fast():
+    mock_exit = Mock()
+
+    def raises_typerror():
+        raise TypeError("This thread failed!")
+
+    tevent.spawn(raises_typerror, fail_fast=True, exit=mock_exit)
+

--- a/epu/tevent.py
+++ b/epu/tevent.py
@@ -1,6 +1,9 @@
+import os
+import sys
+import socket
 import weakref
+import traceback
 import threading
-import signal
 from multiprocessing.pool import ThreadPool
 """
 Helper functions for working with stdlib threading library
@@ -8,13 +11,38 @@ Helper functions for working with stdlib threading library
 Inspired by the gevent api
 """
 
-def spawn(func, *args, **kwargs):
+def spawn(func, fail_fast=False, exit=None, *args, **kwargs):
+    """spawn - spawn and start a thread
+
+    @param func - function to run in the thread
+    @param fail_fast - if set to True, if this thread raises an
+        unhandled exception, it will terminate the parent process
+    @param exit - alternate exit function to call to bring down
+        the process
+    """
     if hasattr(func, 'im_class'):
         name = "%s.%s" % (func.im_class.__name__, func.__name__)
     else:
         name = func.__name__
 
-    _thread = threading.Thread(target=func, name=name, args=tuple(args), kwargs=kwargs)
+    if fail_fast == True:
+        def critical_wrapper():
+            try:
+                func()
+            except (Exception, socket.timeout) as e:
+                msg = "%s Thread has died, but it is critical. Exiting." % name
+                print >> sys.stderr, msg
+                if exit is None:
+                    traceback.print_exc()
+                    os._exit(os.EX_SOFTWARE)
+                else:
+                    exit()
+
+        _func = critical_wrapper
+    else:
+        _func = func
+
+    _thread = threading.Thread(target=_func, name=name, args=tuple(args), kwargs=kwargs)
     _thread.daemon = True
     _thread.start()
     return _thread


### PR DESCRIPTION
If a provisioner thread dies, it will take down the whole provisioner
process, which should help with debugging and reliability when deployed
with supervisord
