### PR TITLE
Add the ability to specify spare_slots in engine conf, and make UNSCHEDULED_PENDING processes be considered when calculating needs

### DIFF
--- a/epu/processdispatcher/engines.py
+++ b/epu/processdispatcher/engines.py
@@ -1,5 +1,6 @@
 DOMAIN_PREFIX = "pd_domain_"
 
+
 def engine_id_from_domain(domain_id):
     if not (domain_id and domain_id.startswith(DOMAIN_PREFIX)):
         raise ValueError("domain_id %s doesn't have expected prefix %s" % (
@@ -8,6 +9,7 @@ def engine_id_from_domain(domain_id):
     if not engine_id:
         raise ValueError("domain_id has empty engine id")
     return engine_id
+
 
 def domain_id_from_engine(engine_id):
     if not engine_id and not isinstance(engine_id, basestring):
@@ -33,8 +35,10 @@ class EngineRegistry(object):
         registry = cls(default=default)
         for engine_id, engine_conf in config.iteritems():
             spec = EngineSpec(engine_id, engine_conf['slots'],
-                engine_conf.get('base_need', 0),
-                engine_conf.get('config'), engine_conf.get('replicas', 1))
+                base_need=engine_conf.get('base_need', 0),
+                config=engine_conf.get('config'),
+                replicas=engine_conf.get('replicas', 1),
+                spare_slots=engine_conf.get('spare_slots', 0))
             registry.add(spec)
         return registry
 
@@ -59,15 +63,24 @@ class EngineRegistry(object):
 
 
 class EngineSpec(object):
-    def __init__(self, engine_id, slots, base_need=0, config=None, replicas=1):
+
+    def __init__(self, engine_id, slots, base_need=0, config=None, replicas=1,
+                 spare_slots=0):
         self.engine_id = engine_id
+        self.config = config
+        self.base_need = int(base_need)
+
         slots = int(slots)
         if slots < 1:
             raise ValueError("slots must be a positive integer")
         self.slots = slots
-        self.config = config
-        self.base_need = int(base_need)
+
         replicas = int(replicas)
         if replicas < 1:
             raise ValueError("replicas must be a positive integer")
         self.replicas = replicas
+
+        spare_slots = int(spare_slots)
+        if spare_slots < 0:
+            raise ValueError("spare slots must be at least 0")
+        self.spare_slots = spare_slots

--- a/epu/processdispatcher/matchmaker.py
+++ b/epu/processdispatcher/matchmaker.py
@@ -326,7 +326,8 @@ class PDMatchmaker(object):
                                 matched_resource.node_id)
                         return
 
-                    log.debug("updating %s with node_exclusive %s for %s" % (matched_node.node_id, process.node_exclusive, process.upid))
+                    log.debug("updating %s with node_exclusive %s for %s" % (
+                        matched_node.node_id, process.node_exclusive, process.upid))
                     matched_node.node_exclusive.append(process.node_exclusive)
 
                     try:
@@ -487,13 +488,15 @@ class PDMatchmaker(object):
                     process.state = ProcessState.WAITING
                 else:
                     process.state = ProcessState.REJECTED
-                    log.info("Process %s: no available slots. REJECTED due to START_ONLY queueing mode, and process has started before.",
-                         process.upid)
+                    log.info("Process %s: no available slots. REJECTED due to "
+                             "START_ONLY queueing mode, and process has "
+                             "started before.", process.upid)
             elif process.queueing_mode == QueueingMode.RESTART_ONLY:
                 if process.starts == 0:
                     process.state = ProcessState.REJECTED
-                    log.info("Process %s: no available slots. REJECTED due to RESTART_ONLY queueing mode, and process hasn't started before.",
-                         process.upid)
+                    log.info("Process %s: no available slots. REJECTED due to "
+                             "RESTART_ONLY queueing mode, and process hasn't "
+                             "started before.", process.upid)
                 else:
                     log.info("Process %s: no available slots. WAITING in queue",
                          process.upid)
@@ -585,8 +588,9 @@ class PDMatchmaker(object):
         # by the current process set
         engine = self.engine(engine_id)
 
-        # total number of unique runnable processes in the system
-        process_count = len(process_set)
+        # total number of unique runnable processes in the system plus
+        # minimum free slots
+        process_count = len(process_set) + engine.spare_slots
 
         process_need = int(ceil(process_count / float(engine.slots * engine.replicas)))
         need = max(engine.base_need, len(occupied_node_set), process_need)
@@ -643,7 +647,9 @@ class PDMatchmaker(object):
                     log.warning("Can't find node %s?", node_id)
                     continue
                 if not node.node_exclusive_available(process.node_exclusive):
-                    log.debug("Process %s with node_exclusive %s is not being matched to %s, which has this attribute" % (process.upid, process.node_exclusive, node_id))
+                    log.debug("Process %s with node_exclusive %s is not being "
+                              "matched to %s, which has this attribute" % (
+                                  process.upid, process.node_exclusive, node_id))
                     continue
 
             # now inspect each resource in the node looking for a match

--- a/epu/processdispatcher/store.py
+++ b/epu/processdispatcher/store.py
@@ -661,7 +661,7 @@ class ProcessDispatcherZooKeeperStore(object):
     DOCTOR_ELECTION_PATH = "/elections/doctor"
 
     def __init__(self, hosts, base_path, username=None, password=None,
-        timeout=None, use_gevent=False):
+                 timeout=None, use_gevent=False):
 
         kwargs = zkutil.get_kazoo_kwargs(username=username, password=password,
             timeout=timeout, use_gevent=use_gevent)
@@ -720,7 +720,7 @@ class ProcessDispatcherZooKeeperStore(object):
                 allow_missing_node=True)
 
     def _initialized_watcher(self, data, stat):
-        if not (data == None and stat == None):
+        if not (data is None and stat is None):
             # initialized node exists! set our event and join the party.
             self._is_initialized.set()
             self._party.join()
@@ -731,7 +731,7 @@ class ProcessDispatcherZooKeeperStore(object):
     def _connection_state_listener(self, state):
         # called by kazoo when the connection state changes.
         # handle in background
-        state_listener = tevent.spawn(self._handle_connection_state, state)
+        tevent.spawn(self._handle_connection_state, state)
 
     def _handle_connection_state(self, state):
 

--- a/epu/processdispatcher/test/test_processdispatcher_service.py
+++ b/epu/processdispatcher/test/test_processdispatcher_service.py
@@ -1354,6 +1354,11 @@ class ProcessDispatcherServiceTests(unittest.TestCase):
         self.notifier.wait_for_state('p5', ProcessState.UNSCHEDULED_PENDING)
         self.notifier.wait_for_state('p6', ProcessState.TERMINATED)
 
+        # check that the matchmaker still needs an engine 1 for the
+        # UNSCHEDULED_PENDING processes
+        self.assertEqual(self.pd.matchmaker.registered_needs,
+                         {'engine1': 1, 'engine2': 0})
+
         # add resources back
         self.client.node_state("node1", domain_id_from_engine("engine1"),
             InstanceState.RUNNING)
@@ -1373,7 +1378,6 @@ class ProcessDispatcherServiceTests(unittest.TestCase):
 
         # finally, end system boot mode. the remaining 2 U-P procs should be scheduled
         self.client.set_system_boot(False)
-
         self._wait_assert_pd_dump(self._assert_process_distribution,
                                   node_counts=[4],
                                   queued_count=1)


### PR DESCRIPTION
Pretty simple, no changes to the store or anything like that.
