### PR TITLE
Fix Chef bootstrap procedure to get correct node permissions

### DIFF
--- a/epu/provisioner/chefutil.py
+++ b/epu/provisioner/chefutil.py
@@ -145,7 +145,9 @@ def get_chef_cloudinit_userdata(node_id, server_url, validation_key,
         raise ValueError("invalid attributes: must be a dictionary")
 
     validate_key(validation_key)
-    first_boot = json.dumps(attributes.update({"run_list": run_list}))
+    attributes_with_run_list = dict(attributes)
+    attributes_with_run_list.update({"run_list": run_list})
+    first_boot = json.dumps(attributes_with_run_list)
     vals = dict(validation_key=validation_key, server_url=server_url,
                 node_name=node_id, validator_name=validator_name,
                 first_boot=first_boot)

--- a/epu/provisioner/chefutil.py
+++ b/epu/provisioner/chefutil.py
@@ -1,3 +1,4 @@
+import json
 import string
 
 try:
@@ -9,6 +10,29 @@ from epu.exceptions import NotFoundError, WriteConflictError
 
 DEFAULT_CLIENT_NAME = "admin"
 DEFAULT_VALIDATOR_NAME = "chef-validator"
+
+
+def get_chef_node(node_id, server_url=None, client_key=None, client_name=None):
+    """Return a Chef node from the server
+
+    if server_url and client_key are not specified, a default server will be used
+    (if available.)
+    """
+    if chef is None:
+        raise Exception("pychef library is not available")
+
+    if client_name is None:
+        client_name = DEFAULT_CLIENT_NAME
+
+    api = None
+    if server_url and client_key:
+        validate_key(client_key)
+        api = chef.ChefAPI(server_url, client_key, client_name)
+
+    try:
+        return chef.Node.list(api=api)[node_id]
+    except KeyError:
+        return None
 
 
 def create_chef_node(node_id, attributes, runlist,
@@ -82,6 +106,10 @@ cat >/etc/chef/validation.pem <<END
 ${validation_key}
 END
 
+cat >/etc/chef/first-boot.json <<END
+${first_boot}
+END
+
 cat > /etc/chef/client.rb <<END
 log_level              :info
 log_location           "/var/log/chef/client.log"
@@ -99,18 +127,27 @@ Chef::Log::Formatter.show_time = true
 END
 
 true && curl -L https://www.opscode.com/chef/install.sh | bash
+chef-client -j /etc/chef/first-boot.json
 chef-client -d
 """
 
 
 def get_chef_cloudinit_userdata(node_id, server_url, validation_key,
-                                validator_name=None):
+                                run_list, attributes, validator_name=None):
 
     if validator_name is None:
         validator_name = DEFAULT_VALIDATOR_NAME
 
+    if not attributes:
+        attributes = {}
+
+    if not isinstance(attributes, dict):
+        raise ValueError("invalid attributes: must be a dictionary")
+
     validate_key(validation_key)
+    first_boot = json.dumps(attributes.update({"run_list": run_list}))
     vals = dict(validation_key=validation_key, server_url=server_url,
-                node_name=node_id, validator_name=validator_name)
+                node_name=node_id, validator_name=validator_name,
+                first_boot=first_boot)
     tmpl = string.Template(_CHEF_INSTALL_SH_TMPL)
     return tmpl.safe_substitute(vals)

--- a/epu/provisioner/core.py
+++ b/epu/provisioner/core.py
@@ -434,16 +434,15 @@ class ProvisionerCore(object):
                 raise ProvisioningError("Chef credentials '%s' not found" % credential_name)
 
             server_url = chef_credentials['url']
-            try:
-                chefutil.create_chef_node(one_node['node_id'], attributes, runlist,
-                    server_url, chef_credentials['client_key'],
-                    chef_credentials.get('client_name'))
-            except WriteConflictError:
-                log.warn("Chef node %s already exists in server %s",
-                    one_node['node_id'], server_url)
+            chef_node = chefutil.get_chef_node(one_node['node_id'], server_url,
+                                               chef_credentials['client_key'],
+                                               chef_credentials.get('client_name'))
+            if chef_node is not None:
+                    log.warn("Chef node %s already exists in server %s",
+                             one_node['node_id'], server_url)
 
             spec.userdata = chefutil.get_chef_cloudinit_userdata(one_node['node_id'],
-                server_url, chef_credentials['validator_key'],
+                server_url, chef_credentials['validator_key'], runlist, attributes,
                 chef_credentials.get('validation_client_name'))
         client_token = one_node.get('client_token')
 


### PR DESCRIPTION
Creating the Chef node from the provisioner resulted in wrong
permissions on the Chef node, which wasn't able to update itself.

Instead, run chef-client with the runlist and attributes in a
first-boot.json file, which will create the node on the Chef server.
Only then run chef-client daemonized.
